### PR TITLE
统一项目命名：将 financial-reporter 全部改为 reporter

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -24,12 +24,12 @@ RUN uv venv && \
     uv sync
 
 # 创建日志目录
-RUN mkdir -p /var/log/financial-reporter
+RUN mkdir -p /var/log/reporter
 
 # 复制定时任务配置
-COPY deploy/crontab /etc/cron.d/financial-reporter
-RUN chmod 0644 /etc/cron.d/financial-reporter && \
-    crontab /etc/cron.d/financial-reporter
+COPY deploy/crontab /etc/cron.d/reporter
+RUN chmod 0644 /etc/cron.d/reporter && \
+    crontab /etc/cron.d/reporter
 
 # 创建启动脚本
 RUN cat > /start.sh << 'EOF'
@@ -37,13 +37,13 @@ RUN cat > /start.sh << 'EOF'
 # 启动 cron 服务
 service cron start
 # 保持容器运行
-tail -f /var/log/financial-reporter/daily.log
+tail -f /var/log/reporter/agents.log
 EOF
 
 RUN chmod +x /start.sh
 
 # 暴露日志目录作为数据卷
-VOLUME ["/var/log/financial-reporter"]
+VOLUME ["/var/log/reporter"]
 
 # 启动容器
 CMD ["/start.sh"] 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,11 +10,11 @@
 
 ```bash
 # 1. 上传项目到服务器
-scp -r . user@your-server:/tmp/financial-reporter
+scp -r . user@your-server:/tmp/reporter
 
 # 2. 登录服务器并运行部署脚本
 ssh user@your-server
-cd /tmp/financial-reporter
+cd /tmp/reporter
 sudo bash deploy/deploy.sh
 ```
 
@@ -55,16 +55,16 @@ docker-compose logs -f
 ### 直接部署方式
 ```bash
 # 查看实时日志
-tail -f /var/log/financial-reporter/daily.log
+tail -f /var/log/reporter/agents.log
 
 # 查看历史日志
-cat /var/log/financial-reporter/daily.log
+cat /var/log/reporter/agents.log
 ```
 
 ### Docker 部署方式
 ```bash
 # 查看容器日志
-docker-compose logs financial-reporter
+docker-compose logs reporter
 
 # 查看日志文件
 cat ./logs/daily.log
@@ -79,7 +79,7 @@ cat ./logs/daily.log
 crontab -u reporter -l
 
 # 手动执行任务
-sudo -u reporter bash -c 'cd /opt/financial-reporter && source .venv/bin/activate && python scripts/run.py'
+sudo -u reporter bash -c 'cd /opt/reporter && source .venv/bin/activate && python scripts/run_agents.py'
 
 # 编辑定时任务
 crontab -u reporter -e
@@ -103,7 +103,7 @@ docker-compose build --no-cache
 docker-compose up -d
 
 # 手动执行任务
-docker-compose exec financial-reporter /app/.venv/bin/python /app/scripts/run.py
+docker-compose exec reporter /app/.venv/bin/python /app/scripts/run_agents.py
 ```
 
 ## 故障排查
@@ -111,7 +111,7 @@ docker-compose exec financial-reporter /app/.venv/bin/python /app/scripts/run.py
 ### 1. 检查定时任务是否运行
 ```bash
 # 直接部署
-grep "financial-reporter" /var/log/syslog
+grep "reporter" /var/log/syslog
 
 # Docker 部署
 docker-compose logs | grep -i error
@@ -129,10 +129,10 @@ curl -X POST -H 'Content-type: application/json' --data '{"text":"测试消息"}
 ### 3. 手动测试
 ```bash
 # 直接部署
-sudo -u reporter bash -c 'cd /opt/financial-reporter && source .venv/bin/activate && python scripts/run.py'
+sudo -u reporter bash -c 'cd /opt/reporter && source .venv/bin/activate && python scripts/run_agents.py'
 
 # Docker 部署
-docker-compose exec financial-reporter /app/.venv/bin/python /app/scripts/run.py
+docker-compose exec reporter /app/.venv/bin/python /app/scripts/run_agents.py
 ```
 
 ## 安全注意事项
@@ -147,7 +147,7 @@ docker-compose exec financial-reporter /app/.venv/bin/python /app/scripts/run.py
 ### 直接部署方式
 ```bash
 # 1. 备份当前版本
-sudo cp -r /opt/financial-reporter /opt/financial-reporter.backup
+sudo cp -r /opt/reporter /opt/reporter.backup
 
 # 2. 上传新版本并重新部署
 # ... 按照部署步骤操作

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,5 +1,5 @@
 # 金融新闻报告器定时任务 - Agent系统
 # 每天北京时间早上8点执行所有查询
-0 8 * * * root cd /app && .venv/bin/python scripts/run_agents.py >> /var/log/financial-reporter/agents.log 2>&1
+0 8 * * * root cd /app && .venv/bin/python scripts/run_agents.py >> /var/log/reporter/agents.log 2>&1
 
 # 空行（cron 要求） 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -14,7 +14,7 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 # 项目配置
-PROJECT_NAME="financial-reporter"
+PROJECT_NAME="reporter"
 PROJECT_DIR="/opt/${PROJECT_NAME}"
 SERVICE_USER="reporter"
 PYTHON_VERSION="3.11"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.8'
 
 services:
-  financial-reporter:
+  reporter:
     build:
       context: ..
       dockerfile: deploy/Dockerfile
-    container_name: financial-reporter
+    container_name: reporter
     restart: unless-stopped
     environment:
       # 从 .env 文件加载环境变量
@@ -19,7 +19,7 @@ services:
       - STREAM=${STREAM:-False}
     volumes:
       # 挂载日志目录
-      - ./logs:/var/log/financial-reporter
+      - ./logs:/var/log/reporter
       # 挂载配置文件（如果需要运行时修改）
       - ../.env:/app/.env:ro
     networks:

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -14,7 +14,7 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 # 项目配置
-PROJECT_NAME="financial-reporter"
+PROJECT_NAME="reporter"
 PROJECT_DIR="/opt/${PROJECT_NAME}"
 SERVICE_USER="reporter"
 
@@ -76,7 +76,7 @@ else
 fi
 
 echo -e "${GREEN}定时任务状态:${NC}"
-if crontab -u $SERVICE_USER -l 2>/dev/null | grep -q "financial-reporter"; then
+if crontab -u $SERVICE_USER -l 2>/dev/null | grep -q "reporter"; then
     echo -e "${GREEN}✅ 定时任务正常运行${NC}"
 else
     echo -e "${YELLOW}⚠️  定时任务可能需要重新设置${NC}"


### PR DESCRIPTION
- 项目目录：/opt/financial-reporter → /opt/reporter
- 日志路径：/var/log/financial-reporter → /var/log/reporter
- 容器名称：financial-reporter → reporter
- 更新所有配置文件、脚本、文档中的路径引用
- 统一使用 scripts/run_agents.py 作为执行脚本
- 完全消除命名不一致问题