### PR TITLE
更新Slack webhook URL并解决invalid_blocks问题

### DIFF
--- a/config/tasks.yaml
+++ b/config/tasks.yaml
@@ -4,7 +4,7 @@ description: "统一的财经新闻分析任务配置"
 # 全局配置
 global:
   slack_webhook_url: "https://hooks.slack.com/services/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"
-  use_slack_blocks: true
+  use_slack_blocks: false
   agent_type: "financial"
 
 # 定时任务列表


### PR DESCRIPTION
- 更新webhook为: 2oEtPuhIAFRjc6bryCCmJiXO
- 保持use_slack_blocks: false避免长内容格式错误
- 使用简单文本格式发送26K+字符的分析报告