### PR TITLE
完全移除环境变量依赖，只使用YAML配置

### DIFF
--- a/config/crypto_tasks.yaml
+++ b/config/crypto_tasks.yaml
@@ -3,7 +3,7 @@ description: "加密货币市场分析任务配置"
 
 # 全局配置x
 global:
-  slack_webhook_url: "https://hooks.slack.com/services/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"
+  slack_webhook_url: "https://hooks.slack.com/services/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"
   use_slack_blocks: false
   agent_type: "financial"
 

--- a/config/tasks.yaml
+++ b/config/tasks.yaml
@@ -3,7 +3,7 @@ description: "统一的财经新闻分析任务配置"
 
 # 全局配置
 global:
-  slack_webhook_url: "https://hooks.slack.com/services/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"
+  slack_webhook_url: "https://hooks.slack.com/services/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"
   use_slack_blocks: false
   agent_type: "financial"
 

--- a/src/reporter/agents/base_agent.py
+++ b/src/reporter/agents/base_agent.py
@@ -33,10 +33,7 @@ class BaseAgent(ABC):
         self._validate_config()
     
     def _resolve_env_var(self, value: str) -> str:
-        """解析环境变量"""
-        if isinstance(value, str) and value.startswith('${') and value.endswith('}'):
-            env_var = value[2:-1]
-            return os.getenv(env_var, value)
+        """不再解析环境变量，直接返回配置值"""
         return value
     
     def _validate_config(self) -> None:
@@ -47,14 +44,12 @@ class BaseAgent(ABC):
         if not self.query:
             raise ValueError(f"Agent '{self.agent_id}': 查询内容不能为空")
         
-        # Slack配置从环境变量验证，不再验证tasks.yaml中的配置
-        import os
-        slack_webhook = os.getenv('SLACK_WEBHOOK_URL')
-        if not slack_webhook:
-            raise ValueError(f"Agent '{self.agent_id}': 缺少 SLACK_WEBHOOK_URL 环境变量")
+        # 验证Slack配置 - 只使用YAML文件中的配置
+        if not self.slack_webhook_url:
+            raise ValueError(f"Agent '{self.agent_id}': 缺少 slack_webhook_url 配置")
         
-        if not slack_webhook.startswith('https://hooks.slack.com/'):
-            raise ValueError(f"Agent '{self.agent_id}': SLACK_WEBHOOK_URL 环境变量格式无效")
+        if not self.slack_webhook_url.startswith('https://hooks.slack.com/'):
+            raise ValueError(f"Agent '{self.agent_id}': slack_webhook_url 格式无效，必须是Slack webhook URL")
         
         # 调用子类的验证方法
         self._validate_agent_config()

--- a/src/reporter/agents/financial_agent.py
+++ b/src/reporter/agents/financial_agent.py
@@ -52,16 +52,12 @@ class FinancialAgent(BaseAgent):
     
     def _setup_slack_service(self):
         """设置Slack服务"""
-        # 创建专用的Slack服务实例，优先使用任务配置中的webhook
+        # 创建专用的Slack服务实例，完全使用YAML配置文件中的设置
         slack_config = Config()
         
-        # 如果任务配置中有webhook，使用任务的webhook覆盖默认配置
-        if hasattr(self, 'slack_webhook_url') and self.slack_webhook_url:
-            slack_config.slack_webhook_url = self.slack_webhook_url
-        
-        # 如果任务配置中有use_slack_blocks设置，也使用任务的设置
-        if hasattr(self, 'use_slack_blocks'):
-            slack_config.use_slack_blocks = self.use_slack_blocks
+        # 使用YAML任务配置中的webhook，不使用环境变量
+        slack_config.slack_webhook_url = self.slack_webhook_url
+        slack_config.use_slack_blocks = self.use_slack_blocks
         
         self.slack_service = SlackService(slack_config)
     


### PR DESCRIPTION
- 修改BaseAgent._validate_config，不再检查SLACK_WEBHOOK_URL环境变量
- 修改FinancialAgent._setup_slack_service，完全使用YAML配置
- 禁用_resolve_env_var方法，不再解析环境变量引用
- 确保智能调度器和run_agents都只加载YAML文件中的slack配置
- 每个任务配置文件中的slack_webhook_url将被严格使用