### PR TITLE
修复部署脚本中的crontab和日志问题

### DIFF
--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,5 +1,5 @@
 # 金融新闻报告器智能调度系统
 # 每分钟检查所有配置文件中的任务schedule，自动运行到期任务
-* * * * * root cd /app && .venv/bin/python scripts/run_scheduler.py >> /var/log/reporter/scheduler.log 2>&1
+* * * * * cd /app && .venv/bin/python scripts/run_scheduler.py >> /var/log/reporter/scheduler.log 2>&1
 
 # 空行（cron 要求） 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -115,6 +115,7 @@ fi
 echo -e "${YELLOW}创建日志目录...${NC}"
 mkdir -p /var/log/$PROJECT_NAME
 chown $SERVICE_USER:$SERVICE_USER /var/log/$PROJECT_NAME
+chmod 755 /var/log/$PROJECT_NAME
 
 echo -e "${YELLOW}设置智能调度系统...${NC}"
 # 使用项目中的 crontab 配置文件
@@ -124,9 +125,18 @@ cp "$PROJECT_DIR/deploy/crontab" /tmp/crontab_tmp
 sed -i "s|/app|$PROJECT_DIR|g" /tmp/crontab_tmp
 sed -i "s|/var/log/reporter|/var/log/$PROJECT_NAME|g" /tmp/crontab_tmp
 
-# 安装定时任务
-crontab -u $SERVICE_USER /tmp/crontab_tmp
+# 安装定时任务到指定用户
+sudo -u $SERVICE_USER crontab /tmp/crontab_tmp
 rm -f /tmp/crontab_tmp
+
+# 验证crontab安装
+echo -e "${GREEN}验证crontab安装...${NC}"
+echo "当前crontab内容:"
+sudo -u $SERVICE_USER crontab -l
+
+# 手动运行一次调度器来初始化日志文件
+echo -e "${YELLOW}初始化调度器日志...${NC}"
+sudo -u $SERVICE_USER bash -c "cd $PROJECT_DIR && source .venv/bin/activate && python scripts/run_scheduler.py >> /var/log/$PROJECT_NAME/scheduler.log 2>&1"
 
 echo -e "${GREEN}智能调度系统已安装${NC}"
 


### PR DESCRIPTION
- 移除crontab文件中的用户名，避免安装时冲突
- 改进deploy.sh中的crontab安装方式，使用正确的用户权限
- 添加日志目录权限设置 (chmod 755)
- 添加crontab安装验证和日志初始化
- 确保部署后调度系统立即可用，无需手动修复